### PR TITLE
10up/tms sync fixes

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -54,8 +54,7 @@ function tmsc_update_cursor( $processor, $batch_size = 0, $completed = false ) {
  * @return string
  */
 function tmsc_hash_data( $data ) {
-	$serialize = function_exists( 'igbinary_serialize' ) ? 'igbinary_serialize' : 'serialize';
-	return md5( $serialize( $data ) );
+	return md5( serialize( $data ) );
 }
 
 /**

--- a/inc/class-tmsc-sync.php
+++ b/inc/class-tmsc-sync.php
@@ -96,6 +96,48 @@ class TMSC_Sync {
 			add_action( 'wp_ajax_sync_objects', array( self::$instance, 'sync_objects' ) );
 			add_action( 'wp_ajax_get_option_value', array( self::$instance, 'ajax_get_option_value' ) );
 		}
+
+		add_action( 'rest_api_init', array( self::$instance, 'create_rest_endpoints' ) );
+	}
+
+	public function create_rest_endpoints() {
+		\register_rest_route( 'tmsc/v1', '/sync/', array(
+			'methods' => 'POST',
+			'callback' => array( self::$instance, 'sync_objects' ),
+			'permission_callback' => array( self::$instance, 'authorize_rest_request' ),
+		) );
+
+		\register_rest_route( 'tmsc/v1', '/sync-status/', array(
+			'methods' => 'POST',
+			'callback' => array( self::$instance, 'ajax_get_option_value' ),
+			'permission_callback' => array( self::$instance, 'authorize_rest_request' ),
+		) );
+
+		\register_rest_route( 'tmsc/v1', '/sync-nonce/', array(
+			'methods' => 'POST',
+			'callback' => array( self::$instance, 'get_sync_nonce' ),
+			'permission_callback' => array( self::$instance, 'authorize_rest_request' ),
+		) );
+
+		\register_rest_route( 'tmsc/v1', '/status-nonce/', array(
+			'methods' => 'POST',
+			'callback' => array( self::$instance, 'get_status_nonce' ),
+			'permission_callback' => array( self::$instance, 'authorize_rest_request' ),
+		) );
+	}
+
+	public function authorize_rest_request() {
+		return current_user_can('edit_pages');
+	}
+
+	public function get_sync_nonce() {
+		\wp_send_json_success( array( 'nonce' => \wp_create_nonce( 'tmsc_object_sync' ) ) );
+		exit();
+	}
+
+	public function get_status_nonce() {
+		\wp_send_json_success( array( 'nonce' => \wp_create_nonce( 'wp_admin_js_script' ) ) );
+		exit();
 	}
 
 	/**

--- a/inc/class-tmsc-sync.php
+++ b/inc/class-tmsc-sync.php
@@ -231,7 +231,7 @@ class TMSC_Sync {
                 );
 
                 $assoc_args = array(
-                        'batch_size' => 10,
+                        'batch_size' => 200,
                 );
 
 		if ( ! empty( $assoc_args['reset'] ) ) {

--- a/inc/class-tmsc.php
+++ b/inc/class-tmsc.php
@@ -185,6 +185,8 @@ class TMSC {
 	public function migrate( $processor_class_slug, $assc_args = array() ) {
 		if ( ! defined( 'WP_IMPORTING' ) ) {
 			define( 'WP_IMPORTING', true );
+			define( 'TMSC_IMPORTING', true );
+			define( 'DOING_CRON', true );
 		}
 
 		/**


### PR DESCRIPTION
Minor fixes to the TMSConnect functionality.

- Creates authenticated REST endpoints for requesting and monitoring sync
- Removes the option to use `igbinary_seralize` as this is not really necessary and impacts the creation of development environments
- Defines new constants when doing migrations to avoid kill switches in ElasticPress