### PR TITLE
Fix sync for constituents

### DIFF
--- a/inc/class-tmsc-sync.php
+++ b/inc/class-tmsc-sync.php
@@ -268,13 +268,18 @@ class TMSC_Sync {
 
 	public function actually_sync_objects() {
 		$args = array(
-                        'taxonomy',
-                        'object',
-                );
+			'taxonomy',
+			'object',
+		);
 
-                $assoc_args = array(
-                        'batch_size' => 200,
-                );
+		$processors_cursor = get_option( 'tmsc-processors-cursor' );
+		if ( ! empty( $processors_cursor ) ) {
+			$args = array_keys( $processors_cursor );
+		}
+
+		$assoc_args = array(
+			'batch_size' => 200,
+		);
 
 		if ( ! empty( $assoc_args['reset'] ) ) {
 			$this->reset();


### PR DESCRIPTION
Default to $args only if tmsc-processors-cursor is empty.

Request: https://github.com/a8cteam51/team51-dev-requests/issues/1372

> From the partner:
> 
> If I run the sync via this page, and I select only constituents, it will not sync.
> 
> https://asia.si.edu/wp-admin/edit.php?post_type=tms_object&page=tmsc-sync



What was happening is that `$args` was overwriting the database value with only Taxonomy and Object, leaving all the other selected processors out of the sync process.